### PR TITLE
Fix FFI compatibility issue when building on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/Cisco-Talos/clamav-async-rs"
 license = "GPL-2.0"
 name = "clamav-async"
 repository = "https://github.com/Cisco-Talos/clamav-async-rs"
-version = "0.2.0"
+version = "0.2.1"
 keywords = ["antivirus", "async", "clamav"]
 
 [features]

--- a/src/cvd/head_libclamav.rs
+++ b/src/cvd/head_libclamav.rs
@@ -15,7 +15,10 @@
 // MA 02110-1301, USA.
 
 use super::{HeadError, Meta};
-use std::{borrow::Cow, ffi::CStr};
+use std::{
+    borrow::Cow,
+    ffi::{c_char, CStr},
+};
 
 /// The header of a CVD
 pub struct Header(*mut clamav_sys::cl_cvd);
@@ -25,7 +28,7 @@ impl Meta for Header {
     /// (or CLD) file
     fn from_header_bytes(bytes: &[u8; 512]) -> Result<Self, HeadError> {
         unsafe {
-            let raw = clamav_sys::cl_cvdparse(bytes.as_ptr() as *const i8);
+            let raw = clamav_sys::cl_cvdparse(bytes.as_ptr() as *const c_char);
 
             if raw.is_null() {
                 Err(HeadError::Parse)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -19,7 +19,7 @@ use clamav_sys::cl_engine_field;
 use clamav_sys::{cl_error_t, time_t};
 use core::num;
 use derivative::Derivative;
-use std::ffi::NulError;
+use std::ffi::{c_char, NulError};
 use std::{path::Path, pin::Pin, sync::Arc, time};
 
 #[cfg(windows)]
@@ -45,7 +45,10 @@ pub enum ScanResult {
 }
 
 impl ScanResult {
-    pub(crate) fn from_ffi(scan_result: cl_error_t, c_virname: *const i8) -> Result<Self, Error> {
+    pub(crate) fn from_ffi(
+        scan_result: cl_error_t,
+        c_virname: *const c_char,
+    ) -> Result<Self, Error> {
         use std::ffi::CStr;
 
         match scan_result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub use engine::Error as EngineError;
 pub use error::Error as ClamError;
 use lazy_static::lazy_static;
 use std::{
-    ffi::CStr,
+    ffi::{c_char, CStr},
     pin::Pin,
     sync::{Arc, Mutex, Once},
 };
@@ -112,8 +112,8 @@ pub fn set_msg_callback(cb: MsgCallback) {
 ///
 unsafe extern "C" fn clcb_msg_wrapper(
     severity: clamav_sys::cl_msg,
-    fullmsg: *const i8,
-    msg: *const i8,
+    fullmsg: *const c_char,
+    msg: *const c_char,
     _context: *mut libc::c_void,
 ) {
     // Remap the log level to "standard" Rust log levels


### PR DESCRIPTION
When building on an Apple-silicon (ARM) Mac device, the following error occurs:
```
error[E0308]: mismatched types
--> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/clamav-async-0.2.0/src/engine.rs:56:36 |
|                     CStr::from_ptr(c_virname).to_string_lossy().to_string(),
|                     -------------- ^^^^^^^^^ expected `*const u8`, found `*const i8`
|                     |
|                     arguments to this function are incorrect
|
= note: expected raw pointer `*const u8`
found raw pointer `*const i8`
note: associated function defined here
--> /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ffi/c_str.rs:274:25
```
The issue is using 'i8' directly rather than the FFI type which is c_char.